### PR TITLE
Allows the use of httpOptions and maxRetries on SNS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-event-stream",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "A simple and fast EventStore for AWS.",
   "author": "Rodrigo Pinheiro de Almeida <rpinheiroalmeida@gmail.com>",
   "license": "MIT",

--- a/src/publisher/sns.ts
+++ b/src/publisher/sns.ts
@@ -1,5 +1,5 @@
 
-import { config, SNS } from 'aws-sdk';
+import { config, HTTPOptions, SNS } from 'aws-sdk';
 import { AWSConfig } from '../aws/config';
 import { MessageType } from '../model/message';
 import { HasSubscribers, Publisher, Subscriber, Subscription } from './publisher';
@@ -9,6 +9,8 @@ export interface SNSOption {
     protocol?: Protocols;
     endpointSubscriber?: string;
     endpointUrl?: string;
+    maxRetries?: number;
+    httpOptions?: HTTPOptions;
 }
 
 export enum Protocols {
@@ -28,7 +30,9 @@ export class SNSPublisher implements Publisher, HasSubscribers {
         config.update(awsconfig);
 
         this.sns = new SNS(
-            snsOptions ? { endpoint: snsOptions.endpointUrl } : undefined
+            snsOptions ? { endpoint: snsOptions.endpointUrl, 
+                httpOptions: snsOptions.httpOptions, 
+                maxRetries: snsOptions.maxRetries } : undefined
         );
         this.url = url;
         this.snsOption = snsOptions;


### PR DESCRIPTION
This PR allow that the user passes the httpOptions and maxRetries options when they create a SNSPublisher