### PR TITLE
Add ConditionalExpression in dynamodb

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-event-stream",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/dynamodb/dynamodb-config.ts
+++ b/src/dynamodb/dynamodb-config.ts
@@ -12,6 +12,6 @@ export interface Config {
         maxRetries?: number;
         httpOptions?: HTTPOptions;
         ttl?: number;
-        conditionalExpression?: string;
+        conditionExpression?: string;
     };
 }

--- a/src/dynamodb/dynamodb-config.ts
+++ b/src/dynamodb/dynamodb-config.ts
@@ -12,5 +12,6 @@ export interface Config {
         maxRetries?: number;
         httpOptions?: HTTPOptions;
         ttl?: number;
+        conditionalExpression?: string;
     };
 }

--- a/src/provider/dynamodb.ts
+++ b/src/provider/dynamodb.ts
@@ -40,7 +40,7 @@ export class DynamodbProvider implements PersistenceProvider {
             ttl: this.config.dynamodb.ttl ? (commitTimetampSeconds + this.config.dynamodb.ttl) : undefined,
         };
         const record = {
-            ConditionalExpression: this.config.dynamodb.conditionalExpression,
+            ConditionExpression: this.config.dynamodb.conditionExpression,
             Item: event,
             TableName: this.config.dynamodb.tableName,
         };

--- a/src/provider/dynamodb.ts
+++ b/src/provider/dynamodb.ts
@@ -40,6 +40,7 @@ export class DynamodbProvider implements PersistenceProvider {
             ttl: this.config.dynamodb.ttl ? (commitTimetampSeconds + this.config.dynamodb.ttl) : undefined,
         };
         const record = {
+            ConditionalExpression: this.config.dynamodb.conditionalExpression,
             Item: event,
             TableName: this.config.dynamodb.tableName,
         };

--- a/test/unit/provider/dynamodb-provider.spec.ts
+++ b/test/unit/provider/dynamodb-provider.spec.ts
@@ -104,7 +104,7 @@ describe('EventStory Dynamodb Provider', () => {
                     },
                     dynamodb: {
                         tableName: 'events',
-                        conditionalExpression: 'attribute_not_exists(eventType)',
+                        conditionExpression: 'attribute_not_exists(eventType)',
                     },
                 } as Config;
                 const dynamodbProvider = new DynamodbProvider(dynamodbConfig);
@@ -125,7 +125,7 @@ describe('EventStory Dynamodb Provider', () => {
                             },
                         },
                         TableName: 'events',
-                        ConditionalExpression: 'attribute_not_exists(eventType)',
+                        ConditionExpression: 'attribute_not_exists(eventType)',
                     }
                 );
                 

--- a/test/unit/provider/dynamodb-provider.spec.ts
+++ b/test/unit/provider/dynamodb-provider.spec.ts
@@ -97,6 +97,40 @@ describe('EventStory Dynamodb Provider', () => {
                 );
             });
 
+            it('when the conditionalExpression property is settled in the table', async () => {
+                const dynamodbConfig = {
+                    awsConfig: {
+                        region: 'us-east-1',
+                    },
+                    dynamodb: {
+                        tableName: 'events',
+                        conditionalExpression: 'attribute_not_exists(eventType)',
+                    },
+                } as Config;
+                const dynamodbProvider = new DynamodbProvider(dynamodbConfig);
+                await dynamodbProvider.addEvent({ aggregation: 'orders', id: '1' }, { text: 'EVENT PAYLOAD', eventType: 'SENT' });
+                expect(db.put).toHaveBeenLastCalledWith(
+                    {
+                        Item: {
+                            aggregation_streamid: 'orders:1',
+                            commitTimestamp: NOW.getTime(),
+                            eventType: 'SENT',
+                            payload: {
+                                eventType: 'SENT',
+                                text: 'EVENT PAYLOAD'
+                            },
+                            stream: {
+                                aggregation: 'orders',
+                                id: '1',
+                            },
+                        },
+                        TableName: 'events',
+                        ConditionalExpression: 'attribute_not_exists(eventType)',
+                    }
+                );
+                
+            });
+
             it('when table events exists', async () => {
 
                 const dynamodbProvider = new DynamodbProvider(dynamodbConfig);


### PR DESCRIPTION
Add `ConditionalExpression` to dynamodb, doing an assessment before recording a registry. The Condition Expression will abort if the result is false and no addition will be made.